### PR TITLE
[frontend] tighten reel spacing

### DIFF
--- a/finetune-ERP-frontend-New/src/components/reels/QuickActionsReel.jsx
+++ b/finetune-ERP-frontend-New/src/components/reels/QuickActionsReel.jsx
@@ -34,10 +34,10 @@ export default function QuickActionsReel() {
     },
   ];
   const slides = [
-    <div key="repairs" className="h-full flex items-center">
-      <div className="max-w-5xl mx-auto w-full px-4">
-        <div className="text-center mb-12">
-          <h2 className="text-3xl font-bold text-gray-900 mb-4">
+    <div key="repairs" className="h-full flex">
+      <div className="max-w-5xl mx-auto w-full h-full px-4 flex flex-col items-center justify-center gap-12">
+        <div className="text-center space-y-4">
+          <h2 className="text-3xl font-bold text-gray-900">
             Most Popular Repairs
           </h2>
           <p className="text-lg text-gray-600">
@@ -51,12 +51,12 @@ export default function QuickActionsReel() {
             return (
               <div
                 key={title}
-                className="bg-white shadow-sm hover:shadow-lg transition-transform duration-300 rounded-2xl p-6 flex flex-col items-center text-center hover:scale-105"
+                className="bg-white shadow-sm hover:shadow-lg transition-transform duration-300 rounded-2xl p-6 flex flex-col items-center text-center hover:scale-105 space-y-4"
               >
-                <Icon className={`w-12 h-12 ${color} mb-4`} />
-                <h3 className="text-lg font-semibold mb-2">{title}</h3>
-                <p className="text-3xl font-bold mb-2">{price}</p>
-                <p className="text-gray-600 mb-6">{description}</p>
+                <Icon className={`w-12 h-12 ${color}`} />
+                <h3 className="text-lg font-semibold">{title}</h3>
+                <p className="text-3xl font-bold">{price}</p>
+                <p className="text-gray-600">{description}</p>
                 <Link
                   to={link}
                   className="min-h-[44px] inline-flex items-center justify-center px-5 py-2 rounded-lg bg-gray-900 text-white font-medium hover:bg-yellow-400 hover:text-gray-900 transition-colors"
@@ -68,7 +68,7 @@ export default function QuickActionsReel() {
           })}
         </div>
 
-        <div className="text-center mt-12">
+        <div className="text-center">
           <Link
             to="/repair"
             className="text-gray-900 hover:text-yellow-600 font-medium text-lg"

--- a/finetune-ERP-frontend-New/src/components/reels/TestimonialsReel.jsx
+++ b/finetune-ERP-frontend-New/src/components/reels/TestimonialsReel.jsx
@@ -34,19 +34,19 @@ const testimonials = [
 function TestimonialSlide({ testimonial }) {
   return (
     <div className="w-full flex items-center justify-center px-4">
-      <div className="max-w-2xl mx-auto text-center">
-        <div className="bg-gray-50 rounded-2xl p-8 shadow-lg">
-          <div className="flex justify-center mb-4">
+      <div className="max-w-2xl mx-auto">
+        <div className="bg-gray-50 rounded-2xl p-8 shadow-lg flex flex-col items-center text-center space-y-6">
+          <div className="flex justify-center">
             {[...Array(5)].map((_, i) => (
               <span key={i} className="text-yellow-400 text-xl">
                 ★
               </span>
             ))}
           </div>
-          <blockquote className="text-xl text-gray-900 mb-6 leading-relaxed">
+          <blockquote className="text-xl text-gray-900 leading-relaxed">
             "{testimonial.text}"
           </blockquote>
-          <div className="text-center">
+          <div>
             <p className="font-semibold text-gray-900 text-lg">
               {testimonial.author}
             </p>
@@ -66,19 +66,25 @@ export default function TestimonialsReel() {
   ));
 
   return (
-    <section className="snap-start fullpage-section relative overflow-hidden bg-white">
-      <div className="absolute top-8 left-1/2 transform -translate-x-1/2 z-10">
-        <h2 className="text-3xl font-bold text-gray-900 text-center">
-          What Our Customers Say
-        </h2>
-        <p className="text-gray-600 text-center mt-2">
-          Real feedback from customers across Coimbatore & Palakkad
-        </p>
-      </div>
+    <section className="snap-start fullpage-section overflow-hidden bg-white">
+      <div className="h-full flex flex-col items-center justify-center gap-8 px-4">
+        <div className="text-center space-y-2">
+          <h2 className="text-3xl font-bold text-gray-900">
+            What Our Customers Say
+          </h2>
+          <p className="text-gray-600">
+            Real feedback from customers across Coimbatore & Palakkad
+          </p>
+        </div>
 
-      <MultiSlideReel reelId="testimonials" className="pt-20" showHint>
-        {slides}
-      </MultiSlideReel>
+        <MultiSlideReel
+          reelId="testimonials"
+          showHint
+          className="w-full flex-1"
+        >
+          {slides}
+        </MultiSlideReel>
+      </div>
     </section>
   );
 }


### PR DESCRIPTION
1. **Problem**
- QuickActions and Testimonials reels used large top/bottom margins causing content to overflow fullpage sections.

2. **Approach**
- Replaced margin-based spacing with flex and gap/space utilities to center slide content within the viewport.

3. **Tests**
- `pnpm --prefix finetune-ERP-frontend-New lint`
- `pnpm --prefix finetune-ERP-frontend-New test`

4. **Risks**
- Updated spacing may require further tuning on smaller screens.

5. **Rollback**
- Revert this commit to restore previous reel layouts.

------
https://chatgpt.com/codex/tasks/task_e_68bfe8d20b888324b061e564057e96d4