### PR TITLE
[frontend] harmonize reel backgrounds

### DIFF
--- a/finetune-ERP-frontend-New/docs/FRONTEND.md
+++ b/finetune-ERP-frontend-New/docs/FRONTEND.md
@@ -17,6 +17,8 @@
   press, or swipe advances exactly one reel using `requestAnimationFrame` over a
   600ms `easeInOutCubic` animation and respects `prefers-reduced-motion`.
 - `TestimonialsReel` cycles through customer testimonials.
+- Consecutive reels use vertical gradient backgrounds and reduced vertical gaps
+  so each carousel fits comfortably within a single viewport.
 
 ## Booking Form
 

--- a/finetune-ERP-frontend-New/src/components/reels/HeroReel.jsx
+++ b/finetune-ERP-frontend-New/src/components/reels/HeroReel.jsx
@@ -6,7 +6,7 @@ export default function HeroReel() {
   const slides = [
     <div key="hero" className="relative flex items-center h-full">
       <div className="absolute inset-0 bg-black/60" />
-      <div className="relative z-10 grid grid-cols-1 lg:grid-cols-2 gap-12 items-center max-w-7xl mx-auto px-4">
+      <div className="relative z-10 grid grid-cols-1 lg:grid-cols-2 gap-8 items-center max-w-7xl mx-auto px-4">
         {/* Left: Text and CTAs */}
         <div className="text-center lg:text-left">
           <p className="text-gray-300 text-sm sm:text-base mb-3 font-medium">
@@ -15,12 +15,12 @@ export default function HeroReel() {
           <h1 className="text-white text-3xl sm:text-4xl lg:text-5xl font-bold leading-tight mb-4">
             Expert Mobile & Laptop Repairs
           </h1>
-          <p className="text-gray-200 text-lg sm:text-xl mb-8 max-w-lg mx-auto lg:mx-0">
+          <p className="text-gray-200 text-lg sm:text-xl mb-6 max-w-lg mx-auto lg:mx-0">
             Same-day repairs • Free pickup & delivery • 90-day warranty
           </p>
 
           {/* CTAs */}
-          <div className="flex flex-col sm:flex-row gap-4 justify-center lg:justify-start mb-8">
+          <div className="flex flex-col sm:flex-row gap-4 justify-center lg:justify-start mb-6">
             <Link
               to="/repair"
               className="bg-gray-900 text-white px-8 py-4 rounded-lg font-semibold hover:bg-yellow-400 hover:text-gray-900 transition-colors"
@@ -36,7 +36,7 @@ export default function HeroReel() {
           </div>
 
           {/* Trust indicators */}
-          <div className="flex items-center gap-6 text-gray-300 text-sm justify-center lg:justify-start">
+          <div className="flex items-center gap-4 text-gray-300 text-sm justify-center lg:justify-start">
             <div className="flex items-center gap-1">
               <span className="text-yellow-400">★</span>
               <span>4.6/5 rating</span>
@@ -60,7 +60,7 @@ export default function HeroReel() {
   ];
 
   return (
-    <section className="snap-start fullpage-section overflow-hidden bg-gradient-to-r from-black via-amber-600/30 to-yellow-400/40">
+    <section className="snap-start fullpage-section overflow-hidden bg-gradient-to-b from-black via-amber-600/30 to-yellow-400/40">
       <MultiSlideReel reelId="hero" showHint={false}>
         {slides}
       </MultiSlideReel>

--- a/finetune-ERP-frontend-New/src/components/reels/QuickActionsReel.jsx
+++ b/finetune-ERP-frontend-New/src/components/reels/QuickActionsReel.jsx
@@ -35,8 +35,8 @@ export default function QuickActionsReel() {
   ];
   const slides = [
     <div key="repairs" className="h-full flex">
-      <div className="max-w-5xl mx-auto w-full h-full px-4 flex flex-col items-center justify-center gap-12">
-        <div className="text-center space-y-4">
+      <div className="max-w-5xl mx-auto w-full h-full px-4 flex flex-col items-center justify-center gap-8">
+        <div className="text-center space-y-2">
           <h2 className="text-3xl font-bold text-gray-900">
             Most Popular Repairs
           </h2>
@@ -51,7 +51,7 @@ export default function QuickActionsReel() {
             return (
               <div
                 key={title}
-                className="bg-white shadow-sm hover:shadow-lg transition-transform duration-300 rounded-2xl p-6 flex flex-col items-center text-center hover:scale-105 space-y-4"
+                className="bg-white shadow-sm hover:shadow-lg transition-transform duration-300 rounded-2xl p-6 flex flex-col items-center text-center hover:scale-105 space-y-3"
               >
                 <Icon className={`w-12 h-12 ${color}`} />
                 <h3 className="text-lg font-semibold">{title}</h3>
@@ -81,7 +81,7 @@ export default function QuickActionsReel() {
   ];
 
   return (
-    <section className="snap-start fullpage-section overflow-hidden bg-gray-50">
+    <section className="snap-start fullpage-section overflow-hidden bg-gradient-to-b from-yellow-400/40 to-gray-50">
       <MultiSlideReel reelId="quickActions" showHint={false}>
         {slides}
       </MultiSlideReel>

--- a/finetune-ERP-frontend-New/src/components/reels/TestimonialsReel.jsx
+++ b/finetune-ERP-frontend-New/src/components/reels/TestimonialsReel.jsx
@@ -35,7 +35,7 @@ function TestimonialSlide({ testimonial }) {
   return (
     <div className="w-full flex items-center justify-center px-4">
       <div className="max-w-2xl mx-auto">
-        <div className="bg-gray-50 rounded-2xl p-8 shadow-lg flex flex-col items-center text-center space-y-6">
+        <div className="bg-gray-50 rounded-2xl p-6 shadow-lg flex flex-col items-center text-center space-y-4">
           <div className="flex justify-center">
             {[...Array(5)].map((_, i) => (
               <span key={i} className="text-yellow-400 text-xl">
@@ -66,8 +66,8 @@ export default function TestimonialsReel() {
   ));
 
   return (
-    <section className="snap-start fullpage-section overflow-hidden bg-white">
-      <div className="h-full flex flex-col items-center justify-center gap-8 px-4">
+    <section className="snap-start fullpage-section overflow-hidden bg-gradient-to-b from-gray-50 to-white">
+      <div className="h-full flex flex-col items-center justify-center gap-6 px-4">
         <div className="text-center space-y-2">
           <h2 className="text-3xl font-bold text-gray-900">
             What Our Customers Say


### PR DESCRIPTION
## Problem
Reel sections had mismatched backgrounds and excessive vertical spacing, creating jarring transitions and unused space.

## Approach
- Switched reel sections to use vertical gradients that blend between neighbors.
- Tightened margins and gaps inside each reel for a single‑viewport fit.
- Documented the reel gradient and spacing rules.

## Tests
- `pnpm lint`
- `pnpm test`

## Risks
Visual regressions in reel layouts on uncommon viewport sizes.

## Rollback
Revert the commit to restore previous reel styling.

------
https://chatgpt.com/codex/tasks/task_e_68bfecbf4fb08324b6853872e1a4c3aa