### PR TITLE
[frontend] align reel sections with nav heights

### DIFF
--- a/finetune-ERP-frontend-New/FILE_MAP.md
+++ b/finetune-ERP-frontend-New/FILE_MAP.md
@@ -9,3 +9,4 @@
 - `src/components/layout/PageWrapper.jsx` – wraps pages, sets scroll mode, and provides the scroll container in reel mode.
 - `src/index.css` – global styles, including navigation offsets and fullpage scroll behavior.
 - `public/favicon.svg` – site favicon.
+- `src/components/common/PageSection.jsx` – semantic section wrapper that fills the viewport and applies mobile bottom padding in reel mode.

--- a/finetune-ERP-frontend-New/docs/UI_GUIDE.md
+++ b/finetune-ERP-frontend-New/docs/UI_GUIDE.md
@@ -69,6 +69,11 @@ Navigation spacing uses Tailwind utilities and container-based sizing; `BottomNa
 Public routes wrap navigation inside a `ScrollModeProvider` with a stable `h-[100dvh] overflow-hidden` container and an inner `flex flex-col` layout. `TopBar` and `MainNav` sit above a `main` region using `flex-1 min-h-0` that applies `overflow-y-auto` only in scroll mode and `overflow-hidden` in reel mode, which is registered for scroll tracking and applies `scrollPaddingTop` equal to the nav heights. The provider hides the navigation after 100px of downward scrolling on mobile or 200px on desktop; upward scroll reveals it immediately on mobile or after 100px on desktop. In reel mode, `PageWrapper` registers its own scroll container and `PublicLayout` disables its `main` scroll container. Sections should fill the container height (`calc(100dvh - var(--topbar-h,0px) - var(--mainnav-h,0px))`); `BottomNav` exposes its size via `--bottomnav-h` for padding adjustments.
 On desktop, a `Footer` stays hidden until about 85% scroll, then slides into view.
 
+### Reel layout notes
+
+- `PageWrapper` sets its container height to `calc(100vh - var(--topbar-h) - var(--mainnav-h))` and adds bottom padding equal to `--bottomnav-h`.
+- `PageSection` applies bottom padding via `--bottomnav-h` when in reel mode on mobile.
+
 ### Viewport units
 
 The app relies on modern viewport units (`100dvh`) so navigation positions remain stable without JavaScript handlers.

--- a/finetune-ERP-frontend-New/src/components/common/PageSection.jsx
+++ b/finetune-ERP-frontend-New/src/components/common/PageSection.jsx
@@ -13,7 +13,7 @@ export default function PageSection({
   const height = mode === 'reel' ? 'h-full' : 'min-h-screen';
 
   const reelPadding =
-    mode === 'reel' && isMobile ? 'pb-[calc(var(--bottomnav-h,0px)+1rem)]' : '';
+    mode === 'reel' && isMobile ? 'pb-[var(--bottomnav-h,0px)]' : '';
 
   return (
     <section

--- a/finetune-ERP-frontend-New/src/components/layout/PageWrapper.jsx
+++ b/finetune-ERP-frontend-New/src/components/layout/PageWrapper.jsx
@@ -10,7 +10,12 @@ export default function PageWrapper({ mode = 'scroll', children }) {
 
   if (mode === 'reel') {
     return (
-      <div className="h-full overflow-hidden">
+      <div
+        className="overflow-hidden"
+        style={{
+          height: 'calc(100vh - var(--topbar-h) - var(--mainnav-h))',
+        }}
+      >
         <div
           className="h-full overflow-y-auto snap-y snap-mandatory fullpage-scrolling"
           data-scroll-container="true"
@@ -18,7 +23,7 @@ export default function PageWrapper({ mode = 'scroll', children }) {
           style={{
             scrollBehavior: 'auto',
             scrollSnapStop: 'always',
-            paddingTop: 'calc(var(--topbar-h, 0px) + var(--mainnav-h, 0px))',
+            paddingBottom: 'var(--bottomnav-h, 0px)',
           }}
         >
           {children}

--- a/finetune-ERP-frontend-New/src/components/layout/PublicLayout.jsx
+++ b/finetune-ERP-frontend-New/src/components/layout/PublicLayout.jsx
@@ -47,6 +47,7 @@ function PublicLayoutInner() {
           className={`flex-1 min-h-0 ${mode === 'reel' ? 'overflow-hidden' : 'overflow-y-auto'}`}
           style={{
             paddingBottom: isMobile ? 'var(--bottomnav-h, 56px)' : '0',
+            paddingTop: 'calc(var(--topbar-h,0px) + var(--mainnav-h,0px))',
             scrollPaddingTop:
               'calc(var(--topbar-h,0px) + var(--mainnav-h,0px))',
           }}

--- a/finetune-ERP-frontend-New/src/components/reels/HeroReel.jsx
+++ b/finetune-ERP-frontend-New/src/components/reels/HeroReel.jsx
@@ -9,18 +9,18 @@ export default function HeroReel() {
       <div className="relative z-10 grid grid-cols-1 lg:grid-cols-2 gap-8 items-center max-w-7xl mx-auto px-4">
         {/* Left: Text and CTAs */}
         <div className="text-center lg:text-left">
-          <p className="text-gray-300 text-sm sm:text-base mb-3 font-medium">
+          <p className="text-gray-300 text-sm sm:text-base pb-3 font-medium">
             Serving Coimbatore & Palakkad • 10+ Years Trusted
           </p>
-          <h1 className="text-white text-3xl sm:text-4xl lg:text-5xl font-bold leading-tight mb-4">
+          <h1 className="text-white text-3xl sm:text-4xl lg:text-5xl font-bold leading-tight pb-4">
             Expert Mobile & Laptop Repairs
           </h1>
-          <p className="text-gray-200 text-lg sm:text-xl mb-6 max-w-lg mx-auto lg:mx-0">
+          <p className="text-gray-200 text-lg sm:text-xl pb-6 max-w-lg mx-auto lg:mx-0">
             Same-day repairs • Free pickup & delivery • 90-day warranty
           </p>
 
           {/* CTAs */}
-          <div className="flex flex-col sm:flex-row gap-4 justify-center lg:justify-start mb-6">
+          <div className="flex flex-col sm:flex-row gap-4 justify-center lg:justify-start pb-6">
             <Link
               to="/repair"
               className="bg-gray-900 text-white px-8 py-4 rounded-lg font-semibold hover:bg-yellow-400 hover:text-gray-900 transition-colors"

--- a/finetune-ERP-frontend-New/src/index.css
+++ b/finetune-ERP-frontend-New/src/index.css
@@ -114,7 +114,7 @@ html {
 
 /* Optimize performance for fullpage scrolling */
 .fullpage-section {
-  height: calc(100vh - var(--topbar-h, 0px) - var(--mainnav-h, 0px)) !important;
+  height: calc(100vh - var(--topbar-h) - var(--mainnav-h)) !important;
   will-change: transform;
   backface-visibility: hidden;
   transform-style: preserve-3d;


### PR DESCRIPTION
1. **Problem**
- Reel sections didn't consistently account for fixed navigation heights, risking overflow and hidden content.

2. **Approach**
- Calculated reel container height with `calc(100vh - var(--topbar-h) - var(--mainnav-h))` and added dynamic bottom padding.
- Replaced large margins with padding for smoother snap alignment.
- Documented reel layout padding behavior.

3. **Tests**
- `pnpm --prefix finetune-ERP-frontend-New test`

4. **Risks**
- CSS variable dependencies may misbehave if nav heights aren't set.

5. **Rollback**
- Revert commit `feat: refine reel layout spacing`.


------
https://chatgpt.com/codex/tasks/task_e_68bff70bc1788324af9d08db04e4468f