### PR TITLE
[frontend] fix layout offsets

### DIFF
--- a/finetune-ERP-frontend-New/docs/UI_GUIDE.md
+++ b/finetune-ERP-frontend-New/docs/UI_GUIDE.md
@@ -54,7 +54,7 @@ Dark mode is enabled via `class` strategy. Toggle a `dark` class on the root ele
 | `Loader`                                        | `src/components/common`           | full-screen loading spinner                                                                                                                                                                                                                                                                                                                                                                                                                                  |
 | `PageSection`                                   | `src/components/common`           | semantic wrapper that uses `h-full` in reel mode and `min-h-screen` otherwise; adds mobile bottom padding in reel mode                                                                                                                                                                                                                                                                                                                                       |
 |                                                 |
-| `PageWrapper`                                   | `src/components/layout`           | sets scroll mode (`reel` or `scroll`); in reel mode provides the scroll container and offsets for navigation; sections should fill the viewport                                                                                                                                                                                                                                                                                                              |
+| `PageWrapper`                                   | `src/components/layout`           | sets scroll mode (`reel` or `scroll`); in reel mode provides the scroll container; sections should fill the viewport                                                                                                                                                                                                                                                                                                              |
 | `MultiSlideReel`                                | `src/components/layout`           | horizontally scrollable reel with session-aware swipe hints, debounced slide detection, CSS scroll snapping, ScrollModeContext integration, and RTL support                                                                                                                                                                                                                                                                                                                             |
 |                                                 |
 
@@ -71,7 +71,7 @@ On desktop, a `Footer` stays hidden until about 85% scroll, then slides into vie
 
 ### Reel layout notes
 
-- `PageWrapper` sets its container height to `calc(100vh - var(--topbar-h) - var(--mainnav-h))` and adds bottom padding equal to `--bottomnav-h`.
+- `PageWrapper` uses a full-viewport container.
 - `PageSection` applies bottom padding via `--bottomnav-h` when in reel mode on mobile.
 
 ### Viewport units

--- a/finetune-ERP-frontend-New/src/components/layout/PageWrapper.jsx
+++ b/finetune-ERP-frontend-New/src/components/layout/PageWrapper.jsx
@@ -13,7 +13,7 @@ export default function PageWrapper({ mode = 'scroll', children }) {
       <div
         className="overflow-hidden"
         style={{
-          height: 'calc(100vh - var(--topbar-h) - var(--mainnav-h))',
+          height: '100dvh',
         }}
       >
         <div
@@ -23,7 +23,6 @@ export default function PageWrapper({ mode = 'scroll', children }) {
           style={{
             scrollBehavior: 'auto',
             scrollSnapStop: 'always',
-            paddingBottom: 'var(--bottomnav-h, 0px)',
           }}
         >
           {children}
@@ -32,14 +31,5 @@ export default function PageWrapper({ mode = 'scroll', children }) {
     );
   }
 
-  return (
-    <div
-      className="min-h-screen"
-      style={{
-        paddingTop: 'calc(var(--topbar-h, 0px) + var(--mainnav-h, 0px))',
-      }}
-    >
-      {children}
-    </div>
-  );
+  return <div className="min-h-screen">{children}</div>;
 }

--- a/finetune-ERP-frontend-New/src/index.css
+++ b/finetune-ERP-frontend-New/src/index.css
@@ -114,7 +114,9 @@ html {
 
 /* Optimize performance for fullpage scrolling */
 .fullpage-section {
-  height: calc(100vh - var(--topbar-h) - var(--mainnav-h)) !important;
+  height: calc(
+    100vh - var(--topbar-h, 0px) - var(--mainnav-h, 0px)
+  ) !important;
   will-change: transform;
   backface-visibility: hidden;
   transform-style: preserve-3d;


### PR DESCRIPTION
## Problem
- Page content was offset twice by navigation heights.
- Bottom padding applied in both wrapper and sections.
- CSS height calc lacked safe fallbacks for nav variables.

## Approach
- Simplified `PageWrapper` to use full viewport height and removed redundant paddings.
- Restored variable fallbacks for fullpage sections.
- Updated docs to reflect the new layout responsibilities.

## Tests
- `pnpm --prefix finetune-ERP-frontend-New lint`
- `pnpm --prefix finetune-ERP-frontend-New test`

## Risks
- Reel mode sections rely on updated wrapper height; regressions may appear in uncommon viewports.

## Rollback
- Revert commit `4bd8a3e` to restore previous layout behavior.

------
https://chatgpt.com/codex/tasks/task_e_68bfff9028b08324b703a4beb8a4539c