### PR TITLE
[frontend] balance cart page wrappers

### DIFF
--- a/finetune-ERP-frontend-New/src/pages/ecommerce/CartPage.jsx
+++ b/finetune-ERP-frontend-New/src/pages/ecommerce/CartPage.jsx
@@ -277,7 +277,6 @@ function CartPage() {
           )}
         </div>
       </div>
-    </div>
   );
 }
 


### PR DESCRIPTION
1. **Problem**
   * CartPage's JSX contained an extra closing wrapper `<div>` causing the DOM tree to be unbalanced.
2. **Approach**
   * Removed the stray closing tag so the two wrapper `<div>` openings in the main render now have matching closures.
   * Verified the production build via `pnpm run build`.
3. **Tests**
   * `pnpm --prefix finetune-ERP-frontend-New run build`
4. **Risks**
   * Low; change only adjusts markup structure without touching logic.
5. **Rollback**
   * Revert the commit to restore the previous markup structure.


------
https://chatgpt.com/codex/tasks/task_e_68cf5f35080c8324bf98743b2c4a6ec3