### PR TITLE
[frontend] remove reel nav offset padding

### DIFF
--- a/finetune-ERP-frontend-New/src/components/layout/PublicLayout.jsx
+++ b/finetune-ERP-frontend-New/src/components/layout/PublicLayout.jsx
@@ -40,14 +40,16 @@ function PublicLayoutInner() {
   const mainStyles = useMemo(
     () => ({
       paddingBottom: isMobile ? 'var(--bottomnav-h, 56px)' : '0',
-      paddingTop: navOffset,
       scrollPaddingTop: navOffset,
       ...(mode === 'reel'
         ? {
+            paddingTop: 0,
             scrollBehavior: 'auto',
             scrollSnapStop: 'always',
           }
-        : {}),
+        : {
+            paddingTop: navOffset,
+          }),
     }),
     [isMobile, mode, navOffset],
   );


### PR DESCRIPTION
## Problem
Reel scroll mode inherits the global navigation offset padding, leaving a white gap before the first section.

## Approach
Add a mode-specific branch in `PublicLayout` styles so reel mode removes the nav padding while preserving scroll behavior overrides and keeping the offset in scroll mode.

## Tests
- `pnpm test`

## Risks
Low – limited to layout styling for reel mode only.

## Rollback
Revert this commit.


------
https://chatgpt.com/codex/tasks/task_e_68cf764ba6a88324b4cbba7f948dea64