### PR TITLE
[frontend] align reel padding with layout

### DIFF
--- a/finetune-ERP-frontend-New/src/components/layout/MultiSlideReel.jsx
+++ b/finetune-ERP-frontend-New/src/components/layout/MultiSlideReel.jsx
@@ -168,7 +168,7 @@ export default function MultiSlideReel({
             className={
               isVertical
                 ? 'reel-section snap-start'
-                : 'w-full flex-shrink-0 snap-start-x'
+                : 'reel-section flex-shrink-0 snap-start-x w-full'
             }
             data-slide-index={index}
           >

--- a/finetune-ERP-frontend-New/src/index.css
+++ b/finetune-ERP-frontend-New/src/index.css
@@ -134,6 +134,9 @@ html {
   display: flex;
   flex-direction: column;
   justify-content: center;
+}
+
+.reel-vertical .reel-section {
   padding-block: clamp(1.5rem, 3vw, 3rem);
 }
 


### PR DESCRIPTION
1. **Problem**
   - Horizontal reels inherited vertical padding and conflicted with Tailwind spacing, leaving extra whitespace around slides.
2. **Approach**
   - Moved the reel section padding to a vertical-specific selector in `index.css` and reused the shared `.reel-section` styles for horizontal slides so both orientations rely on a single flex layout.
3. **Tests**
   - `pnpm lint` *(fails: repository has pre-existing Prettier violations in unrelated files)*
4. **Risks**
   - Low; touches layout classes for reel slides only.
5. **Rollback**
   - Revert commit `cd3cac0`.


------
https://chatgpt.com/codex/tasks/task_e_68cfa5fb07c88324a6065dd274be7bd0