### PR TITLE
[frontend] Simplify HeroReel background

### DIFF
--- a/finetune-ERP-frontend-New/src/components/reels/HeroReel.jsx
+++ b/finetune-ERP-frontend-New/src/components/reels/HeroReel.jsx
@@ -133,12 +133,8 @@ export default function HeroReel() {
   const slides = [
     <div
       key="hero"
-      className="relative min-h-[var(--fullpage-section-h)] overflow-hidden"
+      className="relative min-h-[var(--fullpage-section-h)] overflow-hidden bg-gradient-to-br from-gray-800 via-gray-900 to-gray-950"
     >
-      <div className="absolute inset-0 bg-gradient-to-br from-gray-800 via-gray-900 to-gray-950" />
-      <div className="absolute inset-0 opacity-20 mix-blend-screen" aria-hidden>
-        <div className="h-full w-full bg-[radial-gradient(circle_at_top,_rgba(226,195,61,0.25),_transparent_55%)]" />
-      </div>
       <div className="relative z-10 mx-auto flex h-full w-full max-w-7xl items-center px-4 sm:px-6 lg:px-8">
 
         {isMobile ? <MobileLayout /> : <DesktopLayout />}


### PR DESCRIPTION
1. **Problem**
   - The Hero reel used stacked absolutely positioned background layers, which conflicted with the desired background handling pattern.

2. **Approach**
   - Applied the gradient background directly to the slide container and removed the extra overlay elements to match the working pattern.

3. **Tests**
   - `pnpm lint` *(fails: repository contains pre-existing Prettier formatting violations in unrelated files)*

4. **Risks**
   - Minimal; only adjusts background styling on the hero slide container.

5. **Rollback**
   - Revert the commit `[frontend] Simplify HeroReel background`.


------
https://chatgpt.com/codex/tasks/task_e_68cfb17d02ec832483a53b9ef12fd5b8