### PR TITLE
[frontend] fix SectionSlider horizontal height

### DIFF
--- a/finetune-ERP-frontend-New/src/components/navigation/SectionSlider.jsx
+++ b/finetune-ERP-frontend-New/src/components/navigation/SectionSlider.jsx
@@ -125,14 +125,22 @@ export default function SectionSlider({
     [isVertical]
   );
 
+  const containerClasses = [
+    'relative',
+    isVertical ? 'h-full' : 'min-h-[var(--fullpage-section-h,100vh)]',
+    className,
+  ]
+    .filter(Boolean)
+    .join(' ');
+
   return (
-    <div className={`relative h-full ${className}`} style={style}>
+    <div className={containerClasses} style={style}>
       <div
         ref={containerRef}
         className={
           isVertical
             ? 'reel-vertical h-full overflow-y-auto snap-y snap-mandatory'
-            : 'h-full overflow-x-auto flex snap-x snap-mandatory'
+            : 'min-h-[var(--fullpage-section-h,100vh)] overflow-x-auto flex snap-x snap-mandatory'
         }
         style={
           isVertical

--- a/finetune-ERP-frontend-New/src/index.css
+++ b/finetune-ERP-frontend-New/src/index.css
@@ -131,7 +131,7 @@ html {
 
 /* Fix horizontal reel section height for backgrounds */
 .reel-section {
-  min-height: 100vh;
+  min-height: var(--fullpage-section-h, 100vh);
   display: flex;
   flex-direction: column;
   justify-content: center;


### PR DESCRIPTION
## Problem
Horizontal reels inside `SectionSlider` forced full-height containers, causing extra whitespace when slides were shorter than the viewport.

## Approach
- Added conditional container class assembly so horizontal sliders use the `--fullpage-section-h` minimum height instead of `h-full`.
- Updated horizontal viewport styling to respect the CSS variable and adjusted the global `.reel-section` rule to reference the shared height token.

## Tests
- `pnpm --prefix finetune-ERP-frontend-New test`

## Risks
Low – changes are limited to layout sizing for reel sections.

## Rollback
Revert this commit to restore the previous SectionSlider sizing behavior.

------
https://chatgpt.com/codex/tasks/task_e_68d010b361988324b11302d94db79d81