### PR TITLE
[frontend] refine section slider behavior

### DIFF
--- a/finetune-ERP-frontend-New/src/components/common/PageSection.jsx
+++ b/finetune-ERP-frontend-New/src/components/common/PageSection.jsx
@@ -1,4 +1,7 @@
-import { useScrollMode } from '@/components/layout/ScrollModeContext';
+import {
+  useScrollMode,
+  SECTION_SLIDER_MODE,
+} from '@/components/layout/ScrollModeContext';
 import useDevice from '@/hooks/useDevice';
 
 export default function PageSection({
@@ -10,10 +13,11 @@ export default function PageSection({
   const { mode } = useScrollMode();
   const { isMobile } = useDevice();
 
-  const height = mode === 'reel' ? 'h-full' : 'min-h-screen';
+  const isSliderMode = mode === SECTION_SLIDER_MODE;
+  const height = isSliderMode ? 'h-full' : 'min-h-screen';
 
   const reelPadding =
-    mode === 'reel' && isMobile ? 'pb-[var(--bottomnav-h,0px)]' : '';
+    isSliderMode && isMobile ? 'pb-[var(--bottomnav-h,0px)]' : '';
 
   return (
     <section

--- a/finetune-ERP-frontend-New/src/components/layout/PublicLayout.jsx
+++ b/finetune-ERP-frontend-New/src/components/layout/PublicLayout.jsx
@@ -8,6 +8,7 @@ import useDevice from '@/hooks/useDevice';
 import {
   ScrollModeProvider,
   useScrollMode,
+  SECTION_SLIDER_MODE,
 } from '@/components/layout/ScrollModeContext';
 
 function PublicLayoutInner() {
@@ -41,7 +42,7 @@ function PublicLayoutInner() {
     () => ({
       paddingBottom: isMobile ? 'var(--bottomnav-h, 56px)' : '0',
       scrollPaddingTop: navOffset,
-      ...(mode === 'reel'
+      ...(mode === SECTION_SLIDER_MODE
         ? {
             paddingTop: 0,
             scrollBehavior: 'auto',
@@ -64,7 +65,7 @@ function PublicLayoutInner() {
           ref={registerScrollElement}
           data-scroll-container="true"
           className={`flex-1 min-h-0 ${
-            mode === 'reel'
+            mode === SECTION_SLIDER_MODE
               ? 'overflow-y-auto snap-y snap-mandatory fullpage-scrolling'
               : 'overflow-y-auto'
           }`}

--- a/finetune-ERP-frontend-New/src/components/layout/ScrollModeContext.jsx
+++ b/finetune-ERP-frontend-New/src/components/layout/ScrollModeContext.jsx
@@ -9,6 +9,8 @@ import {
 } from 'react';
 import useDevice from '@/hooks/useDevice';
 
+export const SECTION_SLIDER_MODE = 'section-slider';
+
 // eslint-disable-next-line react-refresh/only-export-components
 export const ScrollModeContext = createContext({
   mode: 'scroll',
@@ -20,7 +22,7 @@ export const ScrollModeContext = createContext({
 });
 
 export const ScrollModeProvider = ({ children }) => {
-  const [mode, setMode] = useState('scroll');
+  const [mode, setInternalMode] = useState('scroll');
   const [bottomNavVisible, setBottomNavVisible] = useState(true);
   const [scrollDirection, setScrollDirection] = useState('down');
   const [scrollEl, setScrollEl] = useState(null);
@@ -33,10 +35,14 @@ export const ScrollModeProvider = ({ children }) => {
   const showThreshold = useMemo(() => (isMobile ? 0 : 100), [isMobile]);
   // TODO: detect mouse movement near bottom to reveal nav on desktop
 
+  const setMode = useCallback((nextMode) => {
+    setInternalMode(nextMode === 'reel' ? SECTION_SLIDER_MODE : nextMode);
+  }, []);
+
   const handleScroll = useCallback(
     (e) => {
-      // 🔥 KEY FIX: Don't interfere with fullpage scroll in reel mode
-      if (mode === 'reel') {
+      // 🔥 KEY FIX: Don't interfere with fullpage scroll in section slider mode
+      if (mode === SECTION_SLIDER_MODE) {
         // Allow fullpage scroll logic to work
         return;
       }
@@ -75,9 +81,9 @@ export const ScrollModeProvider = ({ children }) => {
     [mode, bottomNavVisible, hideThreshold, showThreshold]
   );
 
-  // Keep nav visible in reel mode
+  // Keep nav visible in section slider mode
   useEffect(() => {
-    if (mode === 'reel') {
+    if (mode === SECTION_SLIDER_MODE) {
       setBottomNavVisible(true);
     }
     distance.current = 0;
@@ -109,7 +115,7 @@ export const ScrollModeProvider = ({ children }) => {
       registerScrollElement: setScrollEl,
       scrollElement: scrollEl,
     }),
-    [mode, bottomNavVisible, scrollDirection, scrollEl]
+    [mode, bottomNavVisible, scrollDirection, scrollEl, setMode]
   );
 
   return (

--- a/finetune-ERP-frontend-New/src/components/layout/__tests__/ScrollModeContext.test.jsx
+++ b/finetune-ERP-frontend-New/src/components/layout/__tests__/ScrollModeContext.test.jsx
@@ -4,6 +4,7 @@ import { vi, test, expect } from 'vitest';
 import {
   ScrollModeProvider,
   useScrollMode,
+  SECTION_SLIDER_MODE,
 } from '@/components/layout/ScrollModeContext';
 
 vi.stubGlobal('requestAnimationFrame', (cb) => cb());
@@ -13,7 +14,7 @@ test('mode change resets bottom nav visibility', () => {
     <ScrollModeProvider>{children}</ScrollModeProvider>
   );
   const { result } = renderHook(() => useScrollMode(), { wrapper });
-  act(() => result.current.setMode('reel'));
+  act(() => result.current.setMode(SECTION_SLIDER_MODE));
   expect(result.current.bottomNavVisible).toBe(true);
   act(() => result.current.setMode('scroll'));
   expect(result.current.mode).toBe('scroll');

--- a/finetune-ERP-frontend-New/src/components/reels/HeroReel.jsx
+++ b/finetune-ERP-frontend-New/src/components/reels/HeroReel.jsx
@@ -144,7 +144,7 @@ export default function HeroReel() {
 
   return (
     <section className="snap-start fullpage-section overflow-hidden">
-      <SectionSlider mode="horizontal" reelId="hero" showHint={false}>
+      <SectionSlider mode="horizontal" sectionId="hero" showHint={false}>
         {slides}
       </SectionSlider>
     </section>

--- a/finetune-ERP-frontend-New/src/components/reels/QuickActionsReel.jsx
+++ b/finetune-ERP-frontend-New/src/components/reels/QuickActionsReel.jsx
@@ -82,7 +82,7 @@ export default function QuickActionsReel() {
 
   return (
     <section className="snap-start fullpage-section overflow-hidden bg-gradient-to-b from-secondary/40 to-surface">
-      <SectionSlider reelId="quickActions" showHint={false} mode="vertical">
+      <SectionSlider sectionId="quickActions" showHint={false} mode="vertical">
         {slides}
       </SectionSlider>
     </section>

--- a/finetune-ERP-frontend-New/src/components/reels/TestimonialsReel.jsx
+++ b/finetune-ERP-frontend-New/src/components/reels/TestimonialsReel.jsx
@@ -78,7 +78,7 @@ export default function TestimonialsReel() {
         </div>
 
         <SectionSlider
-          reelId="testimonials"
+          sectionId="testimonials"
           showHint
           mode="vertical"
           className="w-full flex-1"

--- a/finetune-ERP-frontend-New/src/pages/Index.jsx
+++ b/finetune-ERP-frontend-New/src/pages/Index.jsx
@@ -1,6 +1,9 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { devLog } from '@/utils/devLog';
-import { useScrollMode } from '@/components/layout/ScrollModeContext';
+import {
+  useScrollMode,
+  SECTION_SLIDER_MODE,
+} from '@/components/layout/ScrollModeContext';
 import HeroReel from '@/components/reels/HeroReel';
 import QuickActionsReel from '@/components/reels/QuickActionsReel';
 import TestimonialsReel from '@/components/reels/TestimonialsReel';
@@ -25,7 +28,7 @@ export default function Index() {
   const { scrollElement, setMode } = useScrollMode();
 
   useEffect(() => {
-    setMode('reel');
+    setMode(SECTION_SLIDER_MODE);
     return () => setMode('scroll');
   }, [setMode]);
 

--- a/finetune-ERP-frontend-New/src/pages/ecommerce/CartPage.jsx
+++ b/finetune-ERP-frontend-New/src/pages/ecommerce/CartPage.jsx
@@ -13,7 +13,10 @@ import {
 } from 'react-icons/hi';
 import Payment from '@/components/ecommerce/Payment';
 import { useEffect, useState } from 'react';
-import { useScrollMode } from '@/components/layout/ScrollModeContext';
+import {
+  useScrollMode,
+  SECTION_SLIDER_MODE,
+} from '@/components/layout/ScrollModeContext';
 
 function CartPage() {
   const dispatch = useDispatch();
@@ -24,7 +27,7 @@ function CartPage() {
   const { setMode } = useScrollMode();
 
   useEffect(() => {
-    setMode('reel');
+    setMode(SECTION_SLIDER_MODE);
     return () => setMode('scroll');
   }, [setMode]);
 


### PR DESCRIPTION
1. **Problem**
   - SectionSlider still forced full-height blocks in horizontal mode and stored hint flags with legacy `reel` naming.
   - Scroll mode context and downstream components relied on the obsolete `reel` identifier, and the slider lacked swipe-settle protection or typed props.
2. **Approach**
   - Introduced a `SECTION_SLIDER_MODE` constant, normalized `setMode`, and updated all consumers plus hint storage keys and IDs to `section` terminology with backward-compatible props.
   - Removed the horizontal `min-h` utility, added vertical-settle detection that temporarily blocks horizontal swipes, and documented props via JSDoc typedefs.
   - Synced tests with the new mode constant.
3. **Tests**
   - `pnpm test`
4. **Risks**
   - Touch gesture handling changes could introduce regressions on older mobile browsers.
5. **Rollback**
   - Revert this commit to restore prior slider behavior and naming conventions.

------
https://chatgpt.com/codex/tasks/task_e_68d0cb4f4f0c8324836cd69b5de9bd94